### PR TITLE
Add FB and Twitter meta tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
 name: Hack and Tell DC
 highlighter: rouge
 markdown: kramdown
+description: show and tell for hackers in DC
+share_image: http://dc.hackandtell.org/assets/images/logo.png

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,22 @@
         <title>{{ page.title }}</title>
         <meta name="viewport" content="width=device-width">
         <link rel="shortcut icon" href="/favicon.ico">
+
+        <!-- Facebook Metatags -->
+        <meta property="og:url" content="http://dc.hackandtell.org{{ page.url}}" />
+        <meta property="og:title" content="{{ page.title }}" />
+        <meta property="og:description" content="{{ site.description }}" />
+        <meta property="og:image" content="{{ site.share_image }}" />
+        <meta property="og:image:width" content="139" />
+        <meta property="og:image:height" content="134" />
         
+        <!-- Twitter Cards -->
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:site" content="@dchackandtell" />
+        <meta name="twitter:title" content="{{ page.title }}" />
+        <meta name="twitter:description" content="{{ site.description }}" />
+        <meta name="twitter:image" content="{{ site.share_image }}" />
+
         <!-- syntax highlighting CSS -->
         <link rel="stylesheet" href="/assets/css/syntax.css">
 


### PR DESCRIPTION
Hey! I'd like to be able to share the dc.hackandtell.org site on FB and Twitter, but the logo and description aren't showing up.  I added some meta tags that should make social sharing a bit better.